### PR TITLE
Fix for #6: NullReferenceException when calling InterimChangeSet<Itinerary>.All.First().ouboundleg

### DIFF
--- a/src/SkyScanner.Console/Program.cs
+++ b/src/SkyScanner.Console/Program.cs
@@ -1,22 +1,24 @@
 ﻿// Copyright (c) 2015 Tamas Vajk. All Rights Reserved. Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
-using System.Configuration;
-using System.Diagnostics;
-using System.Globalization;
-using System.Linq;
-using System.Threading.Tasks;
-using NodaTime;
-using SkyScanner.Booking;
-using SkyScanner.Data;
-using SkyScanner.Data.Interim;
-using SkyScanner.Services;
-using SkyScanner.Settings;
-
 namespace SkyScanner.Console
 {
-    static class Program
-    {
+    using System;
+    using System.Configuration;
+    using System.Diagnostics;
+    using System.Globalization;
+    using System.IO;
+    using System.Linq;
+    using System.Threading.Tasks;
+
+    using NodaTime;
+
+    using SkyScanner.Booking;
+    using SkyScanner.Data;
+    using SkyScanner.Data.Interim;
+    using SkyScanner.Services;
+    using SkyScanner.Settings;
+
+    static class Program {
         static void Main()
         {
             WriteLine("Detailed search:");
@@ -195,10 +197,24 @@ namespace SkyScanner.Console
         }
 
         private static Action<InterimChangeSet<Itinerary>> WriteToDebug()
-        {            
-            return list => Debug.WriteLine($"Interim results recieved ! {list.All.Count()} "
-                                        + $"total itineraries, {list.Additions.Count()} new "
-                                        + $"and {list.Updates.Count()} updates");
+        {
+            return WriteToDebug;
+        }
+
+        private static void WriteToDebug(InterimChangeSet<Itinerary> list)
+        {
+            try
+            {
+                var leg = list.All.First().OutboundLeg;                                
+            }
+            catch(Exception e)
+            {
+                throw new InvalidDataException("The interim result contains legs that are NULL - this should not happen");
+            }
+            
+            Debug.WriteLine($"Interim results recieved ! {list.All.Count()} "
+                                       + $"total itineraries, {list.Additions.Count()} new "
+                                       + $"and {list.Updates.Count()} updates");
         }
 
         private static void WriteBookingResult(BookingResponse response, Currency currentCurrency)

--- a/src/SkyScanner/Services/Base/ResponsePinger.cs
+++ b/src/SkyScanner/Services/Base/ResponsePinger.cs
@@ -40,9 +40,10 @@ namespace SkyScanner.Services.Base
                     var content = await httpResponseMessage.Content.ReadAsStringAsync();
                     var response = JsonConvert.DeserializeObject<TResponse>(content, Scanner.JsonSerializerSettings);
 
+                    this.PostProcess(response);
+
                     if (response.Succeeded)
-                    {
-                        PostProcess(response);
+                    {                        
                         return response;
                     }
 


### PR DESCRIPTION
The `NullReferenceException` was because `PostProcess` wasn't called on the interim results, therefore the `FlightResponse` wasn't set on the instance which caused the properties In- and outbound legs not to be able to resolve the `FlightResponse`. 

I could only reproduce it in Release mode. I added an extra line in the console app that allowed me to re-create the exception, and check whether the fix worked.